### PR TITLE
Make log level configureable

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,6 +11,7 @@ class mimir::config {
   $log_file_path     = $::mimir::log_file_path
   $log_file_mode     = $::mimir::log_file_mode
   $log_group         = $::mimir::log_group
+  $log_level         = $::mimir::log_level
   $log_owner         = $::mimir::log_owner
   $log_to_file       = $::mimir::log_to_file
   $systemd_overrides = $mimir::systemd_overrides
@@ -43,7 +44,7 @@ class mimir::config {
   # This means we cannot define the CONFIG_FILE environment with a drop-in
   file { '/etc/default/mimir':
     ensure  => 'file',
-    content => epp('mimir/systemd-default.epp', {'config_dir' => $config_dir, 'custom_args' => $custom_args}),
+    content => epp('mimir/systemd-default.epp', {'config_dir' => $config_dir, 'custom_args' => $custom_args, 'log_level' => $log_level}),
     owner   => 'root',
     group   => 'root',
     mode    => '0640'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@
 # @param log_file_path Filename to store mimir logs if log to file is enabled
 # @param log_file_mode Mode of the file used to store logs
 # @param log_group Group to use for log resources
+# @param log_level Log level to use for process mimir
 # @param log_owner Owner to use for log resources
 # @param log_to_file Should log be kept in journald or sent to a dedicated file
 # @param validate_cmd Command use to validate configuration
@@ -49,6 +50,7 @@ class mimir (
     String    $log_file_path     = 'mimir.log',
     String    $log_file_mode     = '0600',
     String    $log_group         = 'root',
+    String    $log_level         = 'info',
     String    $log_owner         = 'root',
     Boolean   $log_to_file       = false,
     # Note: https://github.com/grafana/mimir/issues/2588

--- a/spec/classes/mimir_spec.rb
+++ b/spec/classes/mimir_spec.rb
@@ -19,6 +19,7 @@ describe 'mimir' do
         'custom_args'          => [],
         'systemd_overrides'    => nil,
         'log_to_file'          => false,
+        'log_level'            => 'info',
         'restart_cmd'          => '/bin/systemctl reload mimir',
         'restart_on_change'    => false,
         'validate_cmd'         => '/usr/local/bin/mimir --modules=true',
@@ -47,6 +48,7 @@ describe 'mimir' do
         'log_file_path'         => 'mimir-test.log',
         'log_file_mode'         => '0640',
         'log_group'             => 'test_group',
+        'log_level'             => 'debug',
         'log_owner'             => 'test_owner',
         'log_to_file'           => true,
         'restart_cmd'           => '/test/bin/restart',
@@ -136,7 +138,7 @@ describe 'mimir' do
               content:
                 "# MANAGED BY PUPPET\n"\
                 "# Log level. Valid levels: [debug, info, warn, error]. Default: \"info\"\n"\
-                "LOG_LEVEL=\"info\"\n"\
+                "LOG_LEVEL=\"#{params['log_level']}\"\n"\
                 "\n"\
                 "# Path to Mimir YAML configuration file.\n"\
                 "CONFIG_FILE=\"#{params['config_dir']}/config.yml\"\n"\

--- a/templates/systemd-default.epp
+++ b/templates/systemd-default.epp
@@ -1,6 +1,6 @@
 # MANAGED BY PUPPET
 # Log level. Valid levels: [debug, info, warn, error]. Default: "info"
-LOG_LEVEL="info"
+LOG_LEVEL="<%= $log_level %>"
 
 # Path to Mimir YAML configuration file.
 CONFIG_FILE="<%= $config_dir %>/config.yml"


### PR DESCRIPTION
Log level was hardly coded to info inside the environment file.
This PR make this parameter a module argument and add a more complete test to validate the content of the environment file.