### PR TITLE
feat: Implement publish on puppet forge

### DIFF
--- a/.github/workflows/publish_on_forge.yml
+++ b/.github/workflows/publish_on_forge.yml
@@ -1,0 +1,23 @@
+name: Build and publish to Puppet Forge
+
+on:
+ push:
+  tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get latest tag
+      id: vars
+      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+    - name: Clone repository
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ steps.vars.outputs.tag }}
+    - name: Build and publish module
+      uses: barnumbirr/action-forge-publish@v2.7.0
+      env:
+       FORGE_API_KEY: ${{ secrets.FORGE_API_KEY }}
+       REPOSITORY_URL: https://forgeapi.puppet.com/v3/releases

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "ovh-mimir",
-  "version": "6.1.0",
-  "author": "OVHCloud",
+  "version": "1.0.0",
+  "author": "OVHcloud",
   "summary": "Installs, configures, and manages the Grafana mimir service.",
   "license": "Apache-2.0",
   "source": "",


### PR DESCRIPTION
This commit add the ability to publish the module on the puppet forge when a new git tag is added.

Signed-off-by: julien.girard <julien.girard@ovhcloud.com>